### PR TITLE
Make NAT64 prefix a configurable option with default of well-known prefix

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -157,7 +157,7 @@ function drawSprite(ctx, size, targets, sources) {
 // but let's keep it simple and stick with text for now.
 function addrToVersion(addr) {
   if (addr) {
-    if (/^64:ff9b::/.test(addr)) return "4";  // RFC6052
+    if (addr.startsWith(options["nat64Prefix"])) return "4";  // RFC6052
     if (addr.indexOf(".") >= 0) return "4";
     if (addr.indexOf(":") >= 0) return "6";
   }
@@ -808,6 +808,7 @@ const menuId = chrome.contextMenus.create({
 const DEFAULT_OPTIONS = {
   regularColorScheme: "darkfg",
   incognitoColorScheme: "lightfg",
+  nat64Prefix: "64:ff9b::",
 };
 
 function setOptions(newOptions, onDone) {


### PR DESCRIPTION
Initial plumbing to make the NAT64 prefix a configurable option.
This is untested. I'm not a developer, just an interested user.
I definitely do not know how to make the UI changes to present this to the user.
Work toward fixing #13 .